### PR TITLE
Fix Prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,13 @@
   },
   "scripts": {
     "build-css": "postcss globals.css -o tailwind.output.css",
-    "format": "prettier --loglevel warn --write \"{**/*.{jsx,js}\""
+    "format": "prettier --write **/*.{jsx,js}"
   },
   "dependencies": {
     "@types/node": "20.6.2",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
-    "prettier": "2.8.8",
-    "pretty-quick": "^3.1.3",
+    "prettier": "^3.0.3",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.2.2"
   },

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  plugins: ["prettier-plugin-tailwindcss"],
+};

--- a/src/example.jsx
+++ b/src/example.jsx
@@ -1,0 +1,3 @@
+export function Example() {
+  return <div className="bg-slate-400 sm:m-12 sm:p-4">Example</div>;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,7 +4,7 @@ const Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
   },
-  plugins: [import('prettier-plugin-tailwindcss')],
+  plugins: [],
 };
 
 export default Config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,10 +779,10 @@ prettier-plugin-tailwindcss@^0.5.6:
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.6.tgz#8e511857a49bf127f078985f52b04a70e8e92285"
   integrity sha512-2Xgb+GQlkPAUCFi3sV+NOYcSI5XgduvDBL2Zt/hwJudeKXkyvRS65c38SB0yb9UB40+1rL83I6m0RtlOQ8eHdg==
 
-prettier@2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Hey! The prettier configs here aren't correct.

First, `prettier-plugin-tailwindcss` is a Prettier plugin — NOT a Tailwind plugin
Second, the plugin requires Prettier v3
Third, your format script wasn't structured correctly (and `--loglevel` is not a supported option in Prettier's CLI anymore)

This PR fixes those problems.

Ref: https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/223